### PR TITLE
Keep inverted buttons consistent size with regular buttons

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -79,24 +79,6 @@ $govuk-global-styles: true;
 .govuk-button.apply-button,
 .govuk-button.digital-guidance-button {
   background-color: #fff;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.526315em 0.789473em 0.263157em;
-  border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #d9d9d9;
-  -moz-box-shadow: 0 2px 0 #d9d9d9;
-  box-shadow: 0 2px 0 #d9d9d9;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
-  cursor: pointer;
-  color: #0b0c0c;
   font-weight: 700;
   color: #005ea5;
   -webkit-box-shadow: 0 2px 0 #001526;


### PR DESCRIPTION
Before
<img width="150" alt="Screen Shot 2019-06-19 at 17 12 33" src="https://user-images.githubusercontent.com/2445413/59782323-9f3fb880-92b5-11e9-8a43-ec71b399a85b.png">

After
<img width="212" alt="Screen Shot 2019-06-19 at 17 12 27" src="https://user-images.githubusercontent.com/2445413/59782324-9fd84f00-92b5-11e9-84cd-e1000817baeb.png">
