### PR TITLE
Initialise details component

### DIFF
--- a/app/views/damaged.html
+++ b/app/views/damaged.html
@@ -54,11 +54,11 @@
         <button class="govuk-button">Continue</button>
 
       </form>
-      <details class="govuk-details">
+      <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
-      Why the kind of damage matters
-    </span>
+          Why the kind of damage matters
+          </span>
         </summary>
         <div class="govuk-details__text">
           <p>HM Passport Office classes your passport as damaged if:</p>


### PR DESCRIPTION
We're currently in the process of changing the JS initialisation
for some components. Details component now requires `data-module`
for init.

More modern browser handle the details component natively whereas
older browsers like IE rely on the JS polyfill.