### PR TITLE
Update macro paths to newest GOV.UK frontend

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,6 +1,9 @@
 // global styles for <a> and <p> tags
 $govuk-global-styles: true;
 
+// We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework.
+$govuk-assets-path: '/govuk/assets/';
+
 // Import GOV.UK Frontend and any extension styles if extensions have been configured
 @import "lib/extensions/extensions";
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,30 +1,33 @@
-{% extends "template.njk" %}
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
 
-{% from "accordion/macro.njk"        import govukAccordion %}
-{% from "back-link/macro.njk"        import govukBackLink %}
-{% from "breadcrumbs/macro.njk"      import govukBreadcrumbs %}
-{% from "button/macro.njk"           import govukButton %}
-{% from "character-count/macro.njk"  import govukCharacterCount %}
-{% from "checkboxes/macro.njk"       import govukCheckboxes %}
-{% from "date-input/macro.njk"       import govukDateInput %}
-{% from "details/macro.njk"          import govukDetails %}
-{% from "error-message/macro.njk"    import govukErrorMessage %}
-{% from "error-summary/macro.njk"    import govukErrorSummary %}
-{% from "fieldset/macro.njk"         import govukFieldset %}
-{% from "file-upload/macro.njk"      import govukFileUpload %}
-{% from "input/macro.njk"            import govukInput %}
-{% from "inset-text/macro.njk"       import govukInsetText %}
-{% from "panel/macro.njk"            import govukPanel %}
-{% from "phase-banner/macro.njk"     import govukPhaseBanner %}
-{% from "radios/macro.njk"           import govukRadios %}
-{% from "select/macro.njk"           import govukSelect %}
-{% from "skip-link/macro.njk"        import govukSkipLink %}
-{% from "summary-list/macro.njk"     import govukSummaryList %}
-{% from "table/macro.njk"            import govukTable %}
-{% from "tabs/macro.njk"             import govukTabs %}
-{% from "tag/macro.njk"              import govukTag %}
-{% from "textarea/macro.njk"         import govukTextarea %}
-{% from "warning-text/macro.njk"     import govukWarningText %}
+{% extends "govuk/template.njk" %}
+
+{% from "govuk/components/accordion/macro.njk"        import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"           import govukButton %}
+{% from "govuk/components/character-count/macro.njk"  import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"       import govukDateInput %}
+{% from "govuk/components/details/macro.njk"          import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"    import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"      import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"            import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
+{% from "govuk/components/panel/macro.njk"            import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"     import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"           import govukRadios %}
+{% from "govuk/components/select/macro.njk"           import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"        import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"            import govukTable %}
+{% from "govuk/components/tabs/macro.njk"             import govukTabs %}
+{% from "govuk/components/tag/macro.njk"              import govukTag %}
+{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"     import govukWarningText %}
 
 {% block head %}
   {% include "includes/head.html" %}

--- a/lib/extensions/extensions.js
+++ b/lib/extensions/extensions.js
@@ -132,8 +132,8 @@ setExtensionsByType()
 // The hard-coded reference to govuk-frontend allows us to soft launch without a breaking change.  After a hard launch
 // govuk-frontend assets will be served on /extension-assets/govuk-frontend
 const getPublicUrl = config => {
-  if (config.item === '/assets' && config.packageName === 'govuk-frontend') {
-    return '/assets'
+  if (config.item.endsWith('assets') && config.packageName === 'govuk-frontend') {
+    return '/govuk/assets'
   } else {
     return ['', 'extension-assets', config.packageName]
       .concat(config.item.split('/').filter(filterOutParentAndEmpty))


### PR DESCRIPTION
If you try to run this prototype now it doesn’t work, because the version of GOV.UK Frontend that you get if running
```shell
npm install govuk-frontend@^3.0.0
```

introduces a breaking change<sup>1</sup> that came with version 3.0.0 of GOV.UK Frontend.

This repo was using a pre-release version of 3.0.0 in order to get the new focus styles. However when it was updated to 3.0.0 stable it wasn’t also updated<sup>2</sup> to respect the folder structure changes that came with 3.0.0.

This pull request updates the paths to point to the right place.

***

1. https://github.com/alphagov/govuk-frontend/pull/1458
2. https://github.com/alphagov/focus-state-prototype/commit/22d7f9c6186f11e14b5692b4ba637eff456f0783